### PR TITLE
fix(dashboard): load webcomponents polyfill

### DIFF
--- a/dashboard/dialogs/emailfilter.html
+++ b/dashboard/dialogs/emailfilter.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+	<script src="../../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
 	<link rel="import" href="../../bower_components/paper-button/paper-button.html">
 	<link rel="import" href="../../bower_components/paper-tags-input/paper-tags-input.html">
 </head>

--- a/dashboard/dialogs/wordfilter.html
+++ b/dashboard/dialogs/wordfilter.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+	<script src="../../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
 	<link rel="import" href="../../bower_components/paper-button/paper-button.html">
 	<link rel="import" href="../../bower_components/paper-tags-input/paper-tags-input.html">
 </head>

--- a/dashboard/panel.html
+++ b/dashboard/panel.html
@@ -3,6 +3,7 @@
 <head>
 	<meta http-equiv="X-UA-Compatible" content="IE=edge; charset=UTF-8">
 	<meta name="viewport" content="width=device-width" initial-scale="1">
+	<script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
 	<link rel="import" href="../bower_components/paper-button/paper-button.html">
 	<style is="custom-style">
 		paper-button {


### PR DESCRIPTION
Load HTML imports polyfill since it’s no longer supported in Chrome since M80.