### PR TITLE
chore: compatible range to NodeCG 1.0+. v4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lfg-filter",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A primitive word and email address filter for NodeCG.",
   "devDependencies": {
     "babel-eslint": "^6.0.5",
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/SupportClass/lfg-filter#readme",
   "nodecg": {
-    "compatibleRange": "~0.9.0",
+    "compatibleRange": "^1.0.0",
     "dashboardPanels": [
       {
         "name": "filter",


### PR DESCRIPTION
NodeCG Range and version bump intended to address production issue.

No real changes to this project, its a dependency of other things and needs the version changed to match. In my personal opinion, it'd be better to merge this project into lfg-nucleus as they're dependent on each other rather than maintain it separately.